### PR TITLE
Set of 2 trivial fixes

### DIFF
--- a/worker-script.js
+++ b/worker-script.js
@@ -201,7 +201,7 @@ const getHomePageContents = () => {
       }
 
       const response = await fetch(
-        "https://radio-france-rss.aerion.workers.dev/search/?query=" +
+        "${baseUrl}/search/?query=" +
           encodeURIComponent(query)
       );
       const searchResults = await response.json();

--- a/worker-script.js
+++ b/worker-script.js
@@ -61,6 +61,7 @@ const buildFeed = ({ diffusions, showDetails, manifestations }) => {
   };
 
   const escapeXml = (unsafe) => {
+    if (typeof unsafe === 'undefined') return unsafe;
     // From https://stackoverflow.com/a/27979933
     return unsafe.replace(/[<>&'"]/g, function (c) {
       switch (c) {


### PR DESCRIPTION
- use baseUrl everywhere to ease development: It allows to launch the worker with miniflare locally
- Handle empty field case: For instance standfirst field for Tanguy Pastureau chronicles is
undefined.