### PR TITLE
Improve selection of correct manifestation

### DIFF
--- a/worker-script.js
+++ b/worker-script.js
@@ -83,9 +83,10 @@ const buildFeed = ({ diffusions, showDetails, manifestations }) => {
     const manifestation =
       manifestations[
         diffusion.relationships.manifestations.find(
-          (manifId) => manifestations[manifId]?.principal
+          (manifId) => manifestations[manifId]?.principal && !['youtube', 'dailymotion'].includes(manifestations[manifId]?.mediaType)
         )
       ];
+
     const imgUrl = getImgUrl(diffusion.visuals, diffusion.mainImage);
     return `    <item>
           <title>${escapeXml(diffusion.title)}</title>


### PR DESCRIPTION
Some chronicles have several "principal" entries (usually one video and
one audio). The only difference I found is the mediaType (mp3 or
dailymotion).
Since we don't know for sure all medias are mp3 (although I've not found
counter examples yet), it is better to filter out the incorrect
mediaType (which are easier to find because the item is unreadable)

Reference: https://radio-france-rss.aerion.workers.dev/rss/6d36c291-83d7-468a-acb3-36652230cc72