### PR TITLE
Ignore diffusion without mp3 version

### DIFF
--- a/worker-script.js
+++ b/worker-script.js
@@ -86,6 +86,10 @@ const buildFeed = ({ diffusions, showDetails, manifestations }) => {
           (manifId) => manifestations[manifId]?.principal && !['youtube', 'dailymotion'].includes(manifestations[manifId]?.mediaType)
         )
       ];
+    if (typeof manifestation === 'undefined') {
+      console.log(`Item ${diffusion.id} visible at ${diffusion.path} has no mp3 version, skipping`);
+      return '';
+    }
 
     const imgUrl = getImgUrl(diffusion.visuals, diffusion.mainImage);
     return `    <item>


### PR DESCRIPTION
Currently the rss generation fails when a diffusion has no mp3 version.
Now we detect this, warn and move on.

Note: an alternative to this patch could be to introduce any
manifestation (by sorting manifestations instead of searching for one)
Reference: https://radio-france-rss.aerion.workers.dev/rss/eaf66c64-99e0-45a7-8eb3-d74fa59659a2

Change-Id: If5a6cb2777aec49cc96ef911f4ba848c241fe015