### PR TITLE
Use stable ids

### DIFF
--- a/worker-script.js
+++ b/worker-script.js
@@ -91,10 +91,16 @@ const buildFeed = ({ diffusions, showDetails, manifestations }) => {
       return '';
     }
 
+    let guid = diffusion.id;
+    if (new Date(diffusion.createdTime * 1000) <= new Date('Sep 12 2022')) {
+      // backward compatibility: keep old id generation.
+      guid = manifestation.id;
+    }
+
     const imgUrl = getImgUrl(diffusion.visuals, diffusion.mainImage);
     return `    <item>
           <title>${escapeXml(diffusion.title)}</title>
-          <guid>${manifestation.id}</guid>
+          <guid>${guid}</guid>
           ${buildElement("link", diffusion.path)}
           <description>${escapeXml(diffusion.standfirst)}</description>
           <enclosure url="${manifestation.url}" type="audio/mpeg" />


### PR DESCRIPTION
Apple guidelines for podcast feed are to always keep the same id for a given podcast episode.
For radio france emissions publishing new "manifestations" of the same diffusion, we could have a new version of the feed published with a "new" episode (new guid) having the same content (a different manifestation of the same recording).

This patch ensure we use consistent guid even if content changes.

We also keep backward compatibility with previous id assignations (hoping order of `relationships.manifestations` is stable for past diffusions). Othewise, most podcast software would detect new content and redownload it.

Reference: https://podcasters.apple.com/support/823-podcast-requirements
Example: "Camille passe au vert" podcast, with up to 5 manifestations, added progressively after a diffusion.
Change-Id: Iee138f851fa09682cdb9976fdf235ed202e89835